### PR TITLE
Add finding point by category, creating new point and deleting point to API

### DIFF
--- a/src/main/java/org/project/map/controller/MapPointRestController.java
+++ b/src/main/java/org/project/map/controller/MapPointRestController.java
@@ -16,40 +16,141 @@ limitations under the License.
 
 package org.project.map.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.apache.coyote.Response;
 import org.project.map.model.MapPoint;
 import org.project.map.repository.MapPointRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+
+import javax.validation.Valid;
 
 /**
  * Created by pingwin on 25.10.16.
  */
 @RestController
 public class MapPointRestController {
-	
-	
+
+
     @Autowired
     MapPointRepository mapPointRepository;
 
+    /////////////////////////////////////////
+    ////////////GET REQUESTS////////////////
+    ///////////////////////////////////////
+
     @Operation(summary = "Get a list of map points")
-    @RequestMapping("/get")
-    public Iterable<MapPoint> list() {
-        return mapPointRepository.findAll();
+    @RequestMapping(path="/get/all", method= RequestMethod.GET)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Found points in database", content = {
+                    @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = MapPoint.class)))
+            }),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Did not find any points in database", content = @Content)
+    })
+    public ResponseEntity<List<MapPoint>> list() {
+        //Simply return all points
+        return ResponseEntity.ok(mapPointRepository.findAll());
     }
 
-    @Operation(summary = "Get a specific map point by id")
-    @RequestMapping("/get/{id}")
-    public MapPoint getById(@Parameter(description = "id if point to be retreived") @PathVariable(value = "id") long id){
+   @Operation(summary = "Get a specific map point by id")
+   @ApiResponses(value = {
+           @ApiResponse(responseCode = "200", description = "Found point in database with matching ID", content = {
+                   @Content(mediaType = "application/json", schema = @Schema(implementation = MapPoint.class))
+           }),
+           @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+           @ApiResponse(responseCode = "404", description = "Did not find any points in database with supplied ID", content = @Content)
+   })
+   @RequestMapping(path="/get/id/{id}", method= RequestMethod.GET)
+    public ResponseEntity<Optional<MapPoint>> getById(@Parameter(description = "ID of point to be retrieved") @PathVariable(value = "id") long id){
+        //Find a specific point by the ID passed through parameter
         Optional<MapPoint> mpo = mapPointRepository.findById(id);
-        return (mpo.isEmpty()) ? null : mpo.get();
+        return (mpo.isEmpty()) ? ResponseEntity.notFound().build() : ResponseEntity.ok(mpo);
     }
 
+    @Operation(summary = "Get a specific map point by Category")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Found points in database with matching category", content = {
+                    @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = MapPoint.class)))
+            }),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Did not find any points in database with the provided category", content = @Content)
+    })
+    @RequestMapping(path="/get/category/{category}", method= RequestMethod.GET)
+    public ResponseEntity<List<MapPoint>> getByCategory(@Parameter(description = "Category of point to be retrieved") @PathVariable(value = "category") String category){
+        //Get all points that exist
+        Iterable<MapPoint> mpo = mapPointRepository.findAll();
+        //Create a temporary list
+        List<MapPoint> matchingMapPoints = new ArrayList<>();
+        for (MapPoint point : mpo) {
+            if (point.getCategory().equals(category)) {
+                //If the point category matches, add to temporary list
+                matchingMapPoints.add(point);
+            }
+        }
+        //Return temporary list
+        return ResponseEntity.ok(matchingMapPoints);
+    }
+
+    /////////////////////////////////////////
+    ////////////POST REQUESTS///////////////
+    ///////////////////////////////////////
+
+    @Operation(summary = "Create a new point")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Map point created successfully", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = MapPoint.class))
+            }),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+    })
+    @RequestMapping(path="/add/", method= RequestMethod.POST)
+    public ResponseEntity<MapPoint> createMapPoint(
+            @Parameter(description = "MapPoint details to be created", required = true)
+            @Valid @RequestBody MapPoint mapPointRequest) {
+        //Save the new point
+        MapPoint createdMapPoint = mapPointRepository.save(mapPointRequest);
+
+        //Return the point with the appropriate response (201)
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdMapPoint);
+    }
+
+    @Operation(summary = "Delete a specific point by ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Point deleted successfully"),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Did not find any Point with the supplied ID", content = @Content)
+    })
+    @RequestMapping(path="/delete/id/{id}", method= RequestMethod.POST)
+    public ResponseEntity<Void> deleteMapPointById(
+            @Parameter(description = "ID of Point to be deleted", required = true)
+            @PathVariable("id") long id) {
+        //Search for point first
+        Optional<MapPoint> mapPointOptional = mapPointRepository.findById(id);
+
+        if (mapPointOptional.isPresent()) {
+            //If it exists then delete it
+            mapPointRepository.deleteById(id);
+            return ResponseEntity.noContent().build(); // HttpStatus.NO_CONTENT (204)
+        } else {
+            //Otherwise send a 404 response
+            return ResponseEntity.notFound().build(); // HttpStatus.NOT_FOUND (404)
+        }
+    }
 
 }

--- a/src/main/java/org/project/map/controller/MapPointRestController.java
+++ b/src/main/java/org/project/map/controller/MapPointRestController.java
@@ -107,6 +107,80 @@ public class MapPointRestController {
         return ResponseEntity.ok(matchingMapPoints);
     }
 
+    @Operation(summary = "Get map points within a latitude range")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Found points in database within the latitude range", content = {
+                    @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = MapPoint.class)))
+            }),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Did not find any points in the specified latitude range", content = @Content)
+    })
+    @RequestMapping(path="/get/range/lat/{x}/{y}", method= RequestMethod.GET)
+    public ResponseEntity<List<MapPoint>> getByLatitudeRange(
+            @Parameter(description = "Lower bound of latitude range") @PathVariable(value = "x") double x,
+            @Parameter(description = "Upper bound of latitude range") @PathVariable(value = "y") double y) {
+
+        // Get all points that exist
+        Iterable<MapPoint> mpo = mapPointRepository.findAll();
+
+        // Create a temporary list
+        List<MapPoint> pointsInRange = new ArrayList<>();
+
+        for (MapPoint point : mpo) {
+            double lat = point.getLat();
+
+            // Check if the latitude is within the specified range
+            if (lat >= x && lat <= y) {
+                pointsInRange.add(point);
+            }
+        }
+
+        if (!pointsInRange.isEmpty()) {
+            // Return the list of points within the latitude range
+            return ResponseEntity.ok(pointsInRange);
+        } else {
+            // Return 404 if no points found in the specified latitude range
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @Operation(summary = "Get map points within a longitude range")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Found points in database within the longitude range", content = {
+                    @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = MapPoint.class)))
+            }),
+            @ApiResponse(responseCode = "400", description = "Bad request", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Did not find any points in the specified longitude range", content = @Content)
+    })
+    @RequestMapping(path="/get/range/lng/{x}/{y}", method= RequestMethod.GET)
+    public ResponseEntity<List<MapPoint>> getByLongitudeRange(
+            @Parameter(description = "Lower bound of longitude range") @PathVariable(value = "x") double x,
+            @Parameter(description = "Upper bound of longitude range") @PathVariable(value = "y") double y) {
+
+        // Get all points that exist
+        Iterable<MapPoint> mpo = mapPointRepository.findAll();
+
+        // Create a temporary list
+        List<MapPoint> pointsInRange = new ArrayList<>();
+
+        for (MapPoint point : mpo) {
+            double lng = point.getLng();
+
+            // Check if the latitude is within the specified range
+            if (lng >= x && lng <= y) {
+                pointsInRange.add(point);
+            }
+        }
+
+        if (!pointsInRange.isEmpty()) {
+            // Return the list of points within the latitude range
+            return ResponseEntity.ok(pointsInRange);
+        } else {
+            // Return 404 if no points found in the specified latitude range
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     /////////////////////////////////////////
     ////////////POST REQUESTS///////////////
     ///////////////////////////////////////
@@ -150,6 +224,22 @@ public class MapPointRestController {
         } else {
             //Otherwise send a 404 response
             return ResponseEntity.notFound().build(); // HttpStatus.NOT_FOUND (404)
+        }
+    }
+
+    @Operation(summary = "Delete all points")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "All points deleted successfully"),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content)
+    })
+    @RequestMapping(path="/delete/all", method= RequestMethod.POST)
+    public ResponseEntity<Void> deleteAllMapPoints() {
+        mapPointRepository.deleteAll();
+        if (mapPointRepository.count() == 0){
+            return ResponseEntity.noContent().build(); // HttpStatus.NO_CONTENT (204)
+        }
+        else{
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build(); // HttpStatus.INTERNAL_SERVER_ERROR (500)
         }
     }
 

--- a/src/main/resources/static/js/map/map.js
+++ b/src/main/resources/static/js/map/map.js
@@ -6,6 +6,47 @@ var map = L.map( 'map', {
     zoom: 6
 });
 
+//Temporary function for button to test POST request for adding a point
+function createPoint() {
+    //Will only work locally for now until environment variables are introduced in application.properties
+    fetch("http://localhost:8080/add/", {
+        method: "POST",
+        headers: {
+            'Content-Type': "application/json"
+        },
+        body: JSON.stringify({
+            "name": "testapi",
+            "description": "testapidesc",
+            "category": "testapicat",
+            "lat": Math.random()*50-5, //Just some random Points for now
+            "lng": Math.random()*50-5
+        })
+    })
+        .then(response => {
+            console.log(response)
+            if (!response.ok) {
+                //Not in 200 range means something went wrong
+                throw new Error("Network response was not ok");
+            }
+            // Check for 201 status
+            if (response.status === 201) {
+                return response.json();
+            }
+        })
+        .then(data => {
+            console.log(data)
+            // Check if we got valid json data returned with correct map point format
+            if ('id' in data) {
+                alert("Created new point\nid: " + data.id + "\nname: " + data.name + "\ndescription: " + data.description + "\ncategory: " + data.category + "\nlat: " + data.lat + "\nlon: " + data.lng);
+            }
+        })
+        .catch(error => {
+            //Catch previously thrown exception
+            console.error("Error:", error);
+            alert("Error: " + error.message);
+        });
+}
+
 L.tileLayer( 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.github.com/imaginalis">@imaginalis</a>',
     subdomains: ['a','b','c']

--- a/src/main/resources/static/js/map/markers.js
+++ b/src/main/resources/static/js/map/markers.js
@@ -8,7 +8,7 @@ L.layerJSON({
     minShift: 300,				//min shift for update data(in meters)
     updateOutBounds: false,		//request new data only if current bounds higher than last bounds
     layerTarget:layerGroup,
-    url: '/get',
+    url: '/get/all',
     propertyItems: '',
     propertyTitle: 'name',
     propertyLoc: ['lat','lng'],

--- a/src/main/webapp/WEB-INF/view/LeafletJsp.jsp
+++ b/src/main/webapp/WEB-INF/view/LeafletJsp.jsp
@@ -62,7 +62,7 @@ limitations under the License.
             </div>
         </div>
     </nav>
-
+    <button onclick="createPoint()">Create Point!</button>
     <article>
         <header>
             <h1>Leaflet App</h1>
@@ -73,11 +73,7 @@ limitations under the License.
             <div id="loader"></div>
             <p><a href="./swagger-ui/index.html" target="_blank">Swagger (OpenAPI) UI</a></p>
             <p><a href="./api-docs" target="_blank">Swagger (OpenAPI) Json Definition</a></p>
-
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In ac finibus mi. Morbi porttitor urna dui, sed volutpat justo rutrum sit amet. Etiam elementum lacus eget malesuada egestas. Sed id lectus arcu. Pellentesque molestie dignissim diam non commodo. Nunc nec aliquet lectus. Ut a accumsan sapien. Pellentesque sit amet sem nisl. Nulla fringilla vulputate mauris, eleifend dapibus libero. Sed eu cursus orci. In hac habitasse platea dictumst. Vestibulum vel vulputate ex. Nam gravida blandit nisl, at luctus mi interdum ut. Pellentesque et pharetra mi. Proin id placerat diam. Ut porttitor risus in leo tincidunt, a iaculis velit maximus.</p>
-            <p>Nunc bibendum sollicitudin ex, vitae lobortis nunc malesuada eget. Maecenas aliquam aliquam elit, nec rutrum justo blandit sit amet. Cras pellentesque egestas nisi at egestas. Donec lacus ipsum, dignissim a accumsan quis, rutrum ac massa. Vivamus sed dolor nisl. Integer convallis, elit sed euismod molestie, purus velit ornare justo, ac maximus diam odio id felis. Maecenas auctor sed quam ac aliquet. Curabitur tempus sed purus sit amet blandit.</p>
-            <p>Curabitur eget arcu elementum, pulvinar odio ut, dictum tellus. In hac habitasse platea dictumst. Proin sagittis a ex id tempor. Proin faucibus risus non pellentesque vulputate. Morbi augue sem, finibus non leo ut, fermentum auctor massa. Mauris nisi felis, posuere ut efficitur eu, gravida nec enim. Curabitur tempus id nulla in iaculis. Mauris varius accumsan nunc ut pellentesque. Sed placerat vel nisl quis ornare. Ut imperdiet felis et massa facilisis, vel vestibulum erat varius. Etiam tristique dignissim leo, congue tincidunt mi finibus vitae. Suspendisse quis risus eget arcu pharetra tincidunt eu non sapien. Cras sollicitudin, lectus non venenatis ullamcorper, eros quam condimentum libero, nec fermentum purus neque eu eros. Nullam eget blandit nunc. Mauris ultricies sed sapien non aliquam. Etiam bibendum lectus scelerisque neque eleifend, non semper nisi condimentum.</p>
-        </section>
+            </section>
         <footer>
 
         </footer>


### PR DESCRIPTION
Adds the ability to call the following on the API

1.  Finding a list of points by filtering out the category they are under
2.  Sending a POST method with a request body to create a new point
3.  Find and delete a point by its ID

1 and 3 can be tested locally under http://localhost:8080/swagger-ui/index.html#/
2 can be tested with RESTer as shown 
![image](https://github.com/jakubsepiolo2001/COM619-AE1/assets/98393634/0dc53e2a-bec3-4a85-995d-44f09e4bea78)
![image](https://github.com/jakubsepiolo2001/COM619-AE1/assets/98393634/5575f99b-5435-4284-9fe6-a2aa5a197472)

