### PR TITLE
nginx config file ammend for routes to status page

### DIFF
--- a/server/nginx/default.conf
+++ b/server/nginx/default.conf
@@ -9,6 +9,12 @@
         server_name _;
 
         return 301 https://$host$request_uri;
+		
+		location /nginx_status {
+			stub_status;
+				#allow 127.0.0.1; #only allow requests from localhost
+				#deny all; #deny all other hosts
+		}
     }
 
     server {
@@ -26,6 +32,12 @@
 
         location ~ /.well-known/acme-challenge/ {
             root /var/www/certbot;
+        }
+		
+		location /nginx_status {
+            stub_status;
+                #allow 127.0.0.1; #only allow requests from localhost
+                #deny all; #deny all other hosts
         }
     }
 


### PR DESCRIPTION
Small change to the nginx default.conf which displays a ngnix status page under /nginx_status on the live website.